### PR TITLE
Use ci-install.sh for the e-installer

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -1,9 +1,6 @@
 name: Build and Test
 on: [push]
 
-env:
-  MATHWORKS_TOKEN: ${{ secrets.MATHWORKS_TOKEN }}
-
 jobs:
   bat:
     name: Build and Test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "setup-matlab-action",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "setup-matlab-action",
     "author": "The MathWorks, Inc.",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "description": "",
     "main": "lib/index.js",
     "scripts": {

--- a/src/properties.json
+++ b/src/properties.json
@@ -1,4 +1,4 @@
 {
     "matlabDepsUrl": "https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh",
-    "ephemeralInstallerUrl": "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/install.sh"
+    "ephemeralInstallerUrl": "https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh"
 }


### PR DESCRIPTION
Addresses #4 (good catch, @mcafaro 😄 )

Yeah this totally should've been done earlier.. oops 🙈 

With this change though, we can also remove the environment variable used as a workaround for the licws in the integration tests.