### PR TITLE
Shorten action.yml description for marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@
 
 name: Setup MATLAB
 description: >-
-  Set up MATLAB on a Linux-based GitHub-hosted agent
+  Set up MATLAB on a Linux-based GitHub-hosted runner
 inputs:
   release:
     description: >-

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,7 @@ description: >-
 inputs:
   release:
     description: >-
-      MATLAB release to install.
-      You can specify R2020a or a later release.
-      By default, the action installs the latest release of MATLAB.
+      MATLAB release to set up (R2020a or later)
     required: true
     default: latest
 runs:

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 # Copyright 2020 The MathWorks, Inc.
 
-name: Set up MATLAB
+name: Setup MATLAB
 description: >-
-  Setup MATLAB on a Linux-based GitHub-hosted agent
+  Set up MATLAB on a Linux-based GitHub-hosted agent
 inputs:
   release:
     description: >-

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,7 @@
 
 name: Set up MATLAB
 description: >-
-  Install MATLAB on a Linux-based GitHub-hosted agent. Currently, this action is
-  available only for public projects and does not include transformation
-  products, such as MATLAB Coder and MATLAB Compiler.
+  Setup MATLAB on a Linux-based GitHub-hosted agent
 inputs:
   release:
     description: >-


### PR DESCRIPTION
Attempting to get into the marketplace now (woooo 🥳 ). First thing they flag is our descriptions being too long (needs to be < 125 characters). So, I've just grabbed the first sentence since it's straight to the point (the magic is really all @mw-hrastega).

As for the lack of punctuation at the end: that seems to be the trend with other actions 🤔 