### PR TITLE
Add limited, undocumented, Windows and macOS support

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -32,6 +32,12 @@ jobs:
           - os: ubuntu-18.04
             release: R2020a
             command: assert(strcmp(version('-release'),'2020a'))
+          - os: macos-latest
+            release: latest
+            command: assert(~isempty(regexp(version('-release'), '\d{4}.')))
+          - os: windows-latest
+            release: latest
+            command: assert(~isempty(regexp(version('-release'), '\d{4}.')))
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/src/ematlab.ts
+++ b/src/ematlab.ts
@@ -1,0 +1,18 @@
+// Copyright 2022 The MathWorks, Inc.
+
+import fs from "fs";
+import path from "path";
+import os from "os";
+import * as core from "@actions/core";
+
+export const rootFile = path.join(os.tmpdir(), "ephemeral_matlab_root");
+
+export function addToPath() {
+    let root: string;
+    try {
+        root = fs.readFileSync(rootFile).toString();
+    } catch (err) {
+        throw new Error(`Unable to read file containing MATLAB root: ${err.message}`);
+    }
+    core.addPath(path.join(root, "bin"));
+}

--- a/src/ematlab.unit.test.ts
+++ b/src/ematlab.unit.test.ts
@@ -1,0 +1,32 @@
+// Copyright 2022 The MathWorks, Inc.
+
+import * as core from "@actions/core";
+import * as fs from "fs";
+import * as ematlab from "./ematlab";
+
+jest.mock("@actions/core");
+
+afterEach(() => {
+    jest.resetAllMocks();
+});
+
+describe("ephemeral matlab", () => {
+    let addPathMock = core.addPath as jest.Mock;
+
+    beforeEach(() => {
+        addPathMock = core.addPath as jest.Mock;
+        if (fs.existsSync(ematlab.rootFile)) {
+            fs.unlinkSync(ematlab.rootFile);
+        }
+    });
+
+    it("ideally works", async () => {
+        fs.writeFileSync(ematlab.rootFile, "path/to/matlab");
+        ematlab.addToPath();
+        expect(addPathMock).toBeCalledWith("path/to/matlab/bin");
+    });
+
+    it("rejects when root file does not exist", async () => {
+        expect(() => ematlab.addToPath()).toThrow();
+    });
+});

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,8 +1,9 @@
-// Copyright 2020 The MathWorks, Inc.
+// Copyright 2020-2022 The MathWorks, Inc.
 
 import * as core from "@actions/core";
 import properties from "./properties.json";
 import * as script from "./script";
+import * as ematlab from "./ematlab";
 
 export default install;
 
@@ -25,10 +26,12 @@ export async function install(platform: string, release: string) {
 
     // Invoke ephemeral installer to setup a MATLAB on the runner
     await core.group("Setting up MATLAB", () =>
-        script.downloadAndRunScript(platform, properties.ephemeralInstallerUrl, [
-            "--release",
-            release,
-        ])
+        script
+            .downloadAndRunScript(platform, properties.ephemeralInstallerUrl, [
+                "--release",
+                release,
+            ])
+            .then(ematlab.addToPath)
     );
 
     return;

--- a/src/install.ts
+++ b/src/install.ts
@@ -16,10 +16,12 @@ export default install;
  * @param release Release of MATLAB to be set up (e.g., "latest" or "R2020a").
  */
 export async function install(platform: string, release: string) {
-    // Install runtime system dependencies for MATLAB
-    await core.group("Preparing system for MATLAB", () =>
-        script.downloadAndRunScript(platform, properties.matlabDepsUrl, [release])
-    );
+    // Install runtime system dependencies for MATLAB on Linux
+    if (platform === "linux") {
+        await core.group("Preparing system for MATLAB", () =>
+            script.downloadAndRunScript(platform, properties.matlabDepsUrl, [release])
+        );
+    }
 
     // Invoke ephemeral installer to setup a MATLAB on the runner
     await core.group("Setting up MATLAB", () =>

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -3,9 +3,11 @@
 import * as core from "@actions/core";
 import * as install from "./install";
 import * as script from "./script";
+import * as ematlab from "./ematlab";
 
 jest.mock("@actions/core");
 jest.mock("./script");
+jest.mock("./ematlab");
 
 afterEach(() => {
     jest.resetAllMocks();
@@ -13,6 +15,7 @@ afterEach(() => {
 
 describe("install procedure", () => {
     let downloadAndRunScriptMock: jest.Mock<any, any>;
+    let addToPathMock: jest.Mock<any, any>;
 
     // install() does not perform any logic itself on its parameters. Therefore
     // they can be held static for these unit tests
@@ -22,6 +25,7 @@ describe("install procedure", () => {
 
     beforeEach(() => {
         downloadAndRunScriptMock = script.downloadAndRunScript as jest.Mock;
+        addToPathMock = ematlab.addToPath as jest.Mock;
 
         // Mock core.group to simply return the output of the func it gets from
         // the caller
@@ -32,9 +36,11 @@ describe("install procedure", () => {
 
     it("ideally works", async () => {
         downloadAndRunScriptMock.mockResolvedValue(undefined);
+        addToPathMock.mockResolvedValue(undefined);
 
         await expect(doInstall()).resolves.toBeUndefined();
         expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(2);
+        expect(addToPathMock).toHaveBeenCalledTimes(1);
     });
 
     it("rejects when the download fails", async () => {
@@ -52,15 +58,27 @@ describe("install procedure", () => {
 
         await expect(doInstall()).rejects.toBeDefined();
         expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(2);
+        expect(addToPathMock).toHaveBeenCalledTimes(0);
         expect(core.group).toHaveBeenCalledTimes(2);
+    });
+
+    it("rejects when add to path fails", async () => {
+        downloadAndRunScriptMock.mockResolvedValue(undefined);
+        addToPathMock.mockRejectedValueOnce(Error("oof"));
+
+        await expect(doInstall()).rejects.toBeDefined();
+        expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(2);
+        expect(addToPathMock).toHaveBeenCalledTimes(1);
     });
 
     ["darwin", "win32"].forEach((os) => {
         it(`does not run deps script on ${os}`, async () => {
             downloadAndRunScriptMock.mockResolvedValue(undefined);
+            addToPathMock.mockResolvedValue(undefined);
 
             await expect(install.install(os, release)).resolves.toBeUndefined();
             expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(1);
+            expect(addToPathMock).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -54,4 +54,13 @@ describe("install procedure", () => {
         expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(2);
         expect(core.group).toHaveBeenCalledTimes(2);
     });
+
+    ["darwin", "win32"].forEach((os) => {
+        it(`does not run deps script on ${os}`, async () => {
+            downloadAndRunScriptMock.mockResolvedValue(undefined);
+
+            await expect(install.install(os, release)).resolves.toBeUndefined();
+            expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(1);
+        });
+    });
 });


### PR DESCRIPTION
This change adds limited, undocumented, Windows and macOS support for GitHub-hosted runners. Only the core MATLAB and Simulink products (no toolboxes) will be available for these platforms at this time.