### PR TITLE
Do not highlight matlab-batch in log

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -47,4 +47,6 @@ jobs:
         with:
           release: ${{ matrix.release }}
       - name: Run Sample MATLAB Command
-        run: matlab -batch "${{ matrix.command }}"
+        uses: matlab-actions/run-command@v1
+        with:
+          command: ${{ matrix.command }}

--- a/src/install.ts
+++ b/src/install.ts
@@ -31,11 +31,12 @@ export async function install(platform: string, release: string, skipActivationF
             .downloadAndRunScript(platform, properties.ephemeralInstallerUrl, [
                 "--release",
                 release,
-                skipActivationFlag,])
+                skipActivationFlag,
+            ])
             .then(ematlab.addToPath);
 
         const batchInstallDir = matlabBatch.installDir(platform);
-        
+
         const batchResult = script
             .downloadAndRunScript(platform, properties.matlabBatchInstallerUrl, [batchInstallDir])
             .then(() => core.addPath(batchInstallDir));

--- a/src/install.ts
+++ b/src/install.ts
@@ -25,23 +25,22 @@ export async function install(platform: string, release: string, skipActivationF
         );
     }
 
-    // Invoke ephemeral installer to setup a MATLAB on the runner
-    await core.group("Setting up MATLAB", () =>
-        script
+    // Set up MATLAB and matlab-batch
+    await core.group("Setting up MATLAB", () => {
+        const matlabResult = script
             .downloadAndRunScript(platform, properties.ephemeralInstallerUrl, [
                 "--release",
                 release,
-                skipActivationFlag,
-            ])
-            .then(ematlab.addToPath)
-    );
+                skipActivationFlag,])
+            .then(ematlab.addToPath);
 
-    const batchInstallDir = matlabBatch.installDir(platform);
-
-    await core.group("Setting up matlab-batch", () =>
-        script
+        const batchInstallDir = matlabBatch.installDir(platform);
+        
+        const batchResult = script
             .downloadAndRunScript(platform, properties.matlabBatchInstallerUrl, [batchInstallDir])
-            .then(() => core.addPath(batchInstallDir))
-    )
+            .then(() => core.addPath(batchInstallDir));
+
+        return Promise.all([matlabResult, batchResult]);
+    });
     return;
 }

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -59,10 +59,10 @@ describe("install procedure", () => {
     it("rejects when executing the command returns with a non-zero code", async () => {
         downloadAndRunScriptMock
             .mockResolvedValueOnce(undefined)
-            .mockRejectedValueOnce(Error("oof"));
+            .mockRejectedValue(Error("oof"));
 
         await expect(doInstall()).rejects.toBeDefined();
-        expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(2);
+        expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(3);
         expect(addToPathMock).toHaveBeenCalledTimes(0);
         expect(core.group).toHaveBeenCalledTimes(2);
     });
@@ -72,7 +72,7 @@ describe("install procedure", () => {
         addToPathMock.mockRejectedValueOnce(Error("oof"));
 
         await expect(doInstall()).rejects.toBeDefined();
-        expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(2);
+        expect(downloadAndRunScriptMock).toHaveBeenCalledTimes(3);
         expect(addToPathMock).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
matlab-batch is implementation detail but we currently show a header drawing attention to it. This change removes that header and also concurrently installs MATLAB and matlab-batch.