### PR TITLE
Restrict supported releases

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -36,7 +36,7 @@ jobs:
             check-matlab: matlabVer = ver('matlab'); assert(~isempty(matlabVer));
             check-simulink: simulinkVer = ver('simulink'); assert(~isempty(simulinkVer));
           - os: ubuntu-20.04
-            release: R2020a
+            release: R2021bU2
             products: |
               MATLAB
               Simulink

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -36,7 +36,7 @@ jobs:
             check-matlab: matlabVer = ver('matlab'); assert(~isempty(matlabVer));
             check-simulink: simulinkVer = ver('simulink'); assert(~isempty(simulinkVer));
           - os: ubuntu-20.04
-            release: R2021bU2
+            release: R2020a
             products: |
               MATLAB
               Simulink

--- a/src/install.ts
+++ b/src/install.ts
@@ -20,6 +20,9 @@ import * as path from "path";
  */
 export async function install(platform: string, architecture: string, release: string, products: string[]) {
     const releaseInfo = await matlab.getReleaseInfo(release);
+    if (releaseInfo.name < "r2020b") {
+        return Promise.reject(Error(`Release ${releaseInfo.name} is not supported. Use 'R2020b' or a later release.`));
+    }
 
     // Install runtime system dependencies for MATLAB on Linux
     if (platform === "linux") {

--- a/src/install.ts
+++ b/src/install.ts
@@ -21,7 +21,7 @@ import * as path from "path";
 export async function install(platform: string, architecture: string, release: string, products: string[]) {
     const releaseInfo = await matlab.getReleaseInfo(release);
     if (releaseInfo.name < "r2020b") {
-        return Promise.reject(Error(`Release ${releaseInfo.name} is not supported. Use 'R2020b' or a later release.`));
+        return Promise.reject(Error(`Release '${releaseInfo.name}' is not supported. Use 'R2020b' or a later release.`));
     }
 
     // Install runtime system dependencies for MATLAB on Linux

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -92,6 +92,15 @@ describe("install procedure", () => {
         expect(setOutputMock).toHaveBeenCalledTimes(1);
     });
 
+    it("rejects for unsupported MATLAB release", async () => {
+        matlabGetReleaseInfoMock.mockResolvedValue({
+            name: "r2020a",
+            version: "9.8.0",
+            updateNumber: "latest"    
+        });
+        await expect(install.install(platform, arch, "r2020a", products)).rejects.toBeDefined();
+    });
+
     it("rejects for invalid MATLAB version", async () => {
         matlabGetReleaseInfoMock.mockRejectedValue(Error("oof"));
         await expect(doInstall()).rejects.toBeDefined();


### PR DESCRIPTION
Just using lexicographic string ordering to compare releases for now to keep it simple. We can get more complicated in the future if we need to.