### PR TITLE
Don't add the sudo prefix if sudo is not on the path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         },
         "node_modules/@actions/io": {
             "version": "1.1.3",
-            "resolved": "http://mw-npm-repository:80/artifactory/api/npm/npm-repos/@actions/io/-/io-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
             "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
         },
         "node_modules/@actions/tool-cache": {
@@ -5344,7 +5344,7 @@
         },
         "@actions/io": {
             "version": "1.1.3",
-            "resolved": "http://mw-npm-repository:80/artifactory/api/npm/npm-repos/@actions/io/-/io-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
             "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
         },
         "@actions/tool-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@actions/cache": "^3.2.2",
                 "@actions/core": "^1.10.0",
                 "@actions/exec": "^1.1.0",
-                "@actions/io": "^1.1.2",
+                "@actions/io": "^1.1.3",
                 "@actions/tool-cache": "^1.7.1"
             },
             "devDependencies": {
@@ -113,9 +113,9 @@
             }
         },
         "node_modules/@actions/io": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.2.tgz",
-            "integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
+            "version": "1.1.3",
+            "resolved": "http://mw-npm-repository:80/artifactory/api/npm/npm-repos/@actions/io/-/io-1.1.3.tgz",
+            "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
         },
         "node_modules/@actions/tool-cache": {
             "version": "1.7.2",
@@ -5343,9 +5343,9 @@
             }
         },
         "@actions/io": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.2.tgz",
-            "integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
+            "version": "1.1.3",
+            "resolved": "http://mw-npm-repository:80/artifactory/api/npm/npm-repos/@actions/io/-/io-1.1.3.tgz",
+            "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
         },
         "@actions/tool-cache": {
             "version": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@actions/cache": "^3.2.2",
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.0",
-        "@actions/io": "^1.1.2",
+        "@actions/io": "^1.1.3",
         "@actions/tool-cache": "^1.7.1"
     },
     "devDependencies": {

--- a/src/script.ts
+++ b/src/script.ts
@@ -38,12 +38,14 @@ export async function generateExecCommand(platform: string, scriptPath: string):
         try {
             await io.which("sudo", true);
             installCmd = `sudo -E ${installCmd}`;
+            return installCmd;
         } catch {
             // Sudo not available, do not prepend
+            return installCmd;
         }
+    } else {
+        return installCmd;
     }
-
-    return installCmd;
 }
 
 export function defaultInstallRoot(platform: string, programName: string): string {

--- a/src/script.ts
+++ b/src/script.ts
@@ -38,14 +38,12 @@ export async function generateExecCommand(platform: string, scriptPath: string):
         try {
             await io.which("sudo", true);
             installCmd = `sudo -E ${installCmd}`;
-            return installCmd;
         } catch {
             // Sudo not available, do not prepend
-            return installCmd;
         }
-    } else {
-        return installCmd;
     }
+
+    return installCmd;
 }
 
 export function defaultInstallRoot(platform: string, programName: string): string {

--- a/src/script.ts
+++ b/src/script.ts
@@ -35,11 +35,9 @@ export async function generateExecCommand(platform: string, scriptPath: string):
     let installCmd = `bash ${scriptPath}`;
 
     if (platform !== "win32") {
-        try {
-            await io.which("sudo", true);
+        const sudo = await io.which("sudo");
+        if (sudo) {
             installCmd = `sudo -E ${installCmd}`;
-        } catch {
-            // Sudo not available, do not prepend
         }
     }
 

--- a/src/script.unit.test.ts
+++ b/src/script.unit.test.ts
@@ -1,10 +1,12 @@
 // Copyright 2020-2022 The MathWorks, Inc.
 
 import * as exec from "@actions/exec";
+import * as io from "@actions/io";
 import * as toolCache from "@actions/tool-cache";
 import * as script from "./script";
 
 jest.mock("@actions/exec");
+jest.mock("@actions/io");
 jest.mock("@actions/tool-cache");
 
 afterEach(() => {
@@ -56,6 +58,8 @@ describe("script downloader/runner", () => {
 });
 
 describe("install command generator", () => {
+    const whichMock = io.which as jest.Mock;
+
     const scriptPath = "hello.sh";
 
     beforeAll(() => {
@@ -64,13 +68,20 @@ describe("install command generator", () => {
 
     it("does not change the command on Windows", () => {
         const cmd = script.generateExecCommand("win32", scriptPath);
-        expect(cmd).toEqual(`bash ${scriptPath}`);
+        expect(cmd).resolves.toEqual(`bash ${scriptPath}`);
     });
 
     ["darwin", "linux"].forEach((platform) => {
         it(`calls the command with sudo on ${platform}`, () => {
+            whichMock.mockResolvedValue("path/to/sudo"); 
             const cmd = script.generateExecCommand(platform, scriptPath);
-            expect(cmd).toEqual(`sudo -E bash ${scriptPath}`);
+            expect(cmd).resolves.toEqual(`sudo -E bash ${scriptPath}`);
+        });
+
+        it(`calls the command without sudo on ${platform}`, () => {
+            whichMock.mockRejectedValue("No sudo!");
+            const cmd = script.generateExecCommand(platform, scriptPath);
+            expect(cmd).resolves.toEqual(`bash ${scriptPath}`);
         });
     });
 });

--- a/src/script.unit.test.ts
+++ b/src/script.unit.test.ts
@@ -79,7 +79,7 @@ describe("install command generator", () => {
         });
 
         it(`calls the command without sudo on ${platform}`, () => {
-            whichMock.mockRejectedValue("No sudo!");
+            whichMock.mockResolvedValue("");
             const cmd = script.generateExecCommand(platform, scriptPath);
             expect(cmd).resolves.toEqual(`bash ${scriptPath}`);
         });

--- a/src/script.unit.test.ts
+++ b/src/script.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 The MathWorks, Inc.
+// Copyright 2020-2023 The MathWorks, Inc.
 
 import * as exec from "@actions/exec";
 import * as io from "@actions/io";


### PR DESCRIPTION
This change makes it so the prefix `sudo -E` is not added to the bash command if sudo is not on the machine's path.