### PR TITLE
Install Intel version of MATLAB on Apple silicon prior to R2023b

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -58,6 +58,10 @@ jobs:
             products: Symbolic_Math_Toolbox
             check-matlab: matlabVer = ver('matlab'); assert(~isempty(matlabVer));
             check-toolbox: symbolicVer = ver('symbolic'); assert(~isempty(symbolicVer));
+          - os: macos-14
+            release: R2023a
+            check-matlab: matlabVer = ver('matlab'); assert(strcmp(matlabVer.Release,'(R2023a)'));
+            check-toolbox: symbolicVer = ver('symbolic'); assert(strcmp(symbolicVer.Release,'(R2023a)'));
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -60,6 +60,7 @@ jobs:
             check-toolbox: symbolicVer = ver('symbolic'); assert(~isempty(symbolicVer));
           - os: macos-14
             release: R2023a
+            products: Symbolic_Math_Toolbox
             check-matlab: matlabVer = ver('matlab'); assert(strcmp(matlabVer.Release,'(R2023a)'));
             check-toolbox: symbolicVer = ver('symbolic'); assert(strcmp(symbolicVer.Release,'(R2023a)'));
     steps:

--- a/src/install.ts
+++ b/src/install.ts
@@ -24,7 +24,7 @@ export async function install(platform: string, architecture: string, release: s
         return Promise.reject(Error(`Release '${releaseInfo.name}' is not supported. Use 'R2020b' or a later release.`));
     }
     if (platform === "darwin" && architecture === "arm64" && releaseInfo.name < "r2023b") {
-        architecture = "x86";
+        architecture = "x64";
     }
 
     await core.group("Preparing system for MATLAB", async () =>

--- a/src/install.ts
+++ b/src/install.ts
@@ -23,6 +23,9 @@ export async function install(platform: string, architecture: string, release: s
     if (releaseInfo.name < "r2020b") {
         return Promise.reject(Error(`Release '${releaseInfo.name}' is not supported. Use 'R2020b' or a later release.`));
     }
+    if (platform === "darwin" && architecture === "arm64" && releaseInfo.name < "r2023b") {
+        architecture = "x86";
+    }
 
     await core.group("Preparing system for MATLAB", async () =>
         matlab.installSystemDependencies(platform, architecture, releaseInfo.name)

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -128,4 +128,16 @@ describe("install procedure", () => {
         expect(mpmSetupMock).toHaveBeenCalledTimes(1);
         expect(mpmInstallMock).toHaveBeenCalledTimes(1);
     });
+
+    it("installs Intel version on Apple silicon prior to R2023b", async () => {
+        matlabGetReleaseInfoMock.mockResolvedValue({
+            name: "r2023a",
+            version: "9.14.0",
+            updateNumber: "latest"    
+        });
+        await expect(install.install("darwin", "arm64", "r2023a", products, useCache)).resolves.toBeUndefined();
+        expect(matlabInstallSystemDependenciesMock).toHaveBeenCalledWith("darwin","x64","r2023a");
+        expect(matlabSetupBatchMock).toHaveBeenCalledWith("darwin","x64");
+        expect(mpmSetupMock).toHaveBeenCalledWith("darwin","x64");
+    });
 });

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -136,8 +136,8 @@ describe("install procedure", () => {
             updateNumber: "latest"    
         });
         await expect(install.install("darwin", "arm64", "r2023a", products, true)).resolves.toBeUndefined();
-        expect(matlabInstallSystemDependenciesMock).toHaveBeenCalledWith("darwin","arm64","r2023a");
-        expect(matlabSetupBatchMock).toHaveBeenCalledWith("darwin","x64");
-        expect(mpmSetupMock).toHaveBeenCalledWith("darwin","x64");
+        expect(matlabInstallSystemDependenciesMock).toHaveBeenCalledWith("darwin", "arm64", "r2023a");
+        expect(matlabSetupBatchMock).toHaveBeenCalledWith("darwin", "x64");
+        expect(mpmSetupMock).toHaveBeenCalledWith("darwin", "x64");
     });
 });

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -135,8 +135,8 @@ describe("install procedure", () => {
             version: "9.14.0",
             updateNumber: "latest"    
         });
-        await expect(install.install("darwin", "arm64", "r2023a", products, useCache)).resolves.toBeUndefined();
-        expect(matlabInstallSystemDependenciesMock).toHaveBeenCalledWith("darwin","x64","r2023a");
+        await expect(install.install("darwin", "arm64", "r2023a", products, true)).resolves.toBeUndefined();
+        expect(matlabInstallSystemDependenciesMock).toHaveBeenCalledWith("darwin","arm64","r2023a");
         expect(matlabSetupBatchMock).toHaveBeenCalledWith("darwin","x64");
         expect(mpmSetupMock).toHaveBeenCalledWith("darwin","x64");
     });

--- a/src/matlab.ts
+++ b/src/matlab.ts
@@ -207,7 +207,18 @@ export async function installSystemDependencies(platform: string, architecture: 
     if (platform === "linux") {
         return script.downloadAndRunScript(platform, properties.matlabDepsUrl, [release]);
     } else if (platform === "darwin" && architecture === "arm64") {
-        return installAppleSiliconJdk();
+        if (release < "r2023b") {
+            return installAppleSiliconRosetta();
+        } else {
+            return installAppleSiliconJdk();
+        }
+    }
+}
+
+async function installAppleSiliconRosetta() {
+    const exitCode = await exec.exec(`sudo softwareupdate --install-rosetta --agree-to-license`);
+    if (exitCode !== 0) {
+        return Promise.reject(Error("Unable to install Rosetta 2."));
     }
 }
 

--- a/src/matlab.unit.test.ts
+++ b/src/matlab.unit.test.ts
@@ -333,7 +333,6 @@ describe("matlab tests", () => {
 
             it(`works on mac with apple silicon <R2023b`, async () => {
                 const platform = "darwin";
-                tcDownloadToolMock.mockResolvedValue("java.jdk");
                 execMock.mockResolvedValue(0);
                 await expect(
                     matlab.installSystemDependencies(platform, "arm64", "r2023a")

--- a/src/matlab.unit.test.ts
+++ b/src/matlab.unit.test.ts
@@ -285,7 +285,7 @@ describe("matlab tests", () => {
         let tcDownloadToolMock: jest.Mock;
         let execMock: jest.Mock;
         const arch = "x64";
-        const release = "R2023b";
+        const release = "r2023b";
 
         beforeEach(() => {
             downloadAndRunScriptMock = script.downloadAndRunScript as jest.Mock;
@@ -329,6 +329,16 @@ describe("matlab tests", () => {
                 ).resolves.toBeUndefined();
                 expect(tcDownloadToolMock).toHaveBeenCalledWith(properties.appleSiliconJdkUrl, expect.anything());
                 expect(execMock).toHaveBeenCalledWith(`sudo installer -pkg "java.jdk" -target /`);
+            });
+
+            it(`works on mac with apple silicon <R2023b`, async () => {
+                const platform = "darwin";
+                tcDownloadToolMock.mockResolvedValue("java.jdk");
+                execMock.mockResolvedValue(0);
+                await expect(
+                    matlab.installSystemDependencies(platform, "arm64", "r2023a")
+                ).resolves.toBeUndefined();
+                expect(execMock).toHaveBeenCalledWith(`sudo softwareupdate --install-rosetta --agree-to-license`);
             });
         });
 


### PR DESCRIPTION
This pull request adds functionality to install the Intel version of MATLAB on Apple silicon runners when a release prior to R2023b is specified.

Without this functionality, when a release prior to R2023b is specified on an Apple silicon runner, MATLAB will appear to install but fail during execution.

Fixes #112 