### PR TITLE
Do not install core deps on self-hosted runners

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -24,9 +24,12 @@ export async function install(platform: string, architecture: string, release: s
         return Promise.reject(Error(`Release '${releaseInfo.name}' is not supported. Use 'R2020b' or a later release.`));
     }
 
-    await core.group("Preparing system for MATLAB", async () =>
-        matlab.installSystemDependencies(platform, architecture, releaseInfo.name)
-    );
+    // Install system dependencies if cloud-hosted
+    if (process.env["RUNNER_ENVIRONMENT"] === "github-hosted" && process.env["AGENT_ISSELFHOSTED"] !== "1") {
+        await core.group("Preparing system for MATLAB", async () => {
+            await matlab.installSystemDependencies(platform, architecture, releaseInfo.name);
+        });
+    }
 
     await core.group("Setting up MATLAB", async () => {
         let matlabArch = architecture;


### PR DESCRIPTION
This change prepares for supporting `setup-matlab` on self-hosted runners. The action will not attempt to install system dependencies when running on a self-hosted runner, but will still install MATLAB + matlab-batch.