### PR TITLE
Remove MATLAB from the tool cache if mpm fails during installation.

### DIFF
--- a/src/mpm.ts
+++ b/src/mpm.ts
@@ -67,11 +67,13 @@ export async function install(mpmPath: string, release: matlab.Release, products
     }
     mpmArguments = mpmArguments.concat("--products", ...parsedProducts);
 
-    const exitCode = await exec.exec(mpmPath, mpmArguments);
-    if (exitCode !== 0) {
+    const exitCode = await exec.exec(mpmPath, mpmArguments).catch(async e => {
         // Fully remove failed MATLAB installation for self-hosted runners
         await rmRF(destination);
-
+        throw e;
+    });
+    if (exitCode !== 0) {
+        await rmRF(destination);
         return Promise.reject(Error(`Script exited with non-zero code ${exitCode}`));
     }
     return

--- a/src/mpm.ts
+++ b/src/mpm.ts
@@ -2,6 +2,7 @@
 
 import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
+import {rmRF} from "@actions/io";
 import * as path from "path";
 import * as matlab from "./matlab";
 import properties from "./properties.json";
@@ -68,6 +69,9 @@ export async function install(mpmPath: string, release: matlab.Release, products
 
     const exitCode = await exec.exec(mpmPath, mpmArguments);
     if (exitCode !== 0) {
+        // Fully remove failed MATLAB installation for self-hosted runners
+        await rmRF(destination);
+
         return Promise.reject(Error(`Script exited with non-zero code ${exitCode}`));
     }
     return


### PR DESCRIPTION
This is another step in supporting self-hosted runners. Currently if `mpm` fails mid-setup the MATLAB instance is just left in place and will trigger a cache hit on the next job. This causes all sorts of weird errors if the install happens to be incomplete or problematic in some other way.