### PR TITLE
Resolves the error which occurs when calling setup-matlab twice in single workflow

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -89,3 +89,12 @@ jobs:
         with:
           release: ${{ matrix.release }}
           products: ${{ matrix.products }}
+      - name: Call setup MATLAB again with different release # should not error as in issue 130
+        uses: ./
+        with:
+          release: R2023b
+      - name: Check MATLAB version
+        uses: matlab-actions/run-command@v2
+        with:
+          command: matlabVer = ver('matlab'); assert(strcmp(matlabVer.Release,'(R2023b)'));
+  

--- a/src/mpm.ts
+++ b/src/mpm.ts
@@ -4,6 +4,7 @@ import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
 import {rmRF} from "@actions/io";
 import * as path from "path";
+import * as fs from 'fs';
 import * as matlab from "./matlab";
 import properties from "./properties.json";
 
@@ -37,15 +38,21 @@ export async function setup(platform: string, architecture: string): Promise<str
         return Promise.reject(Error("Unable to find runner temporary directory."));
     }
     let mpmDest = path.join(runner_temp, `mpm${ext}`);
-    let mpm: string = await tc.downloadTool(mpmUrl, mpmDest);
+    if (!fs.existsSync(mpmDest)){
+        let mpm: string = await tc.downloadTool(mpmUrl, mpmDest);
 
-    if (platform !== "win32") {
-        const exitCode = await exec.exec(`chmod +x "${mpm}"`);
-        if (exitCode !== 0) {
-            return Promise.reject(Error("Unable to set up mpm."));
+        if (platform !== "win32") {
+            const exitCode = await exec.exec(`chmod +x "${mpm}"`);
+            if (exitCode !== 0) {
+                return Promise.reject(Error("Unable to set up mpm."));
+            }
         }
+
+        return mpm;
     }
-    return mpm
+    else{
+        return mpmDest 
+    }
 }
 
 export async function install(mpmPath: string, release: matlab.Release, products: string[], destination: string) {

--- a/src/mpm.ts
+++ b/src/mpm.ts
@@ -38,21 +38,25 @@ export async function setup(platform: string, architecture: string): Promise<str
         return Promise.reject(Error("Unable to find runner temporary directory."));
     }
     let mpmDest = path.join(runner_temp, `mpm${ext}`);
-    if (!fs.existsSync(mpmDest)){
-        let mpm: string = await tc.downloadTool(mpmUrl, mpmDest);
 
-        if (platform !== "win32") {
-            const exitCode = await exec.exec(`chmod +x "${mpm}"`);
-            if (exitCode !== 0) {
-                return Promise.reject(Error("Unable to set up mpm."));
-            }
+    // Delete mpm file if it exists
+    if (fs.existsSync(mpmDest)) {
+        try {
+            fs.unlinkSync(mpmDest);
+        } catch (err) {
+            return Promise.reject(Error(`Failed to delete existing mpm file: ${err}`));
         }
+    }
 
-        return mpm;
+    let mpm: string = await tc.downloadTool(mpmUrl, mpmDest);
+
+    if (platform !== "win32") {
+        const exitCode = await exec.exec(`chmod +x "${mpm}"`);
+        if (exitCode !== 0) {
+            return Promise.reject(Error("Unable to set up mpm."));
+        }
     }
-    else{
-        return mpmDest 
-    }
+    return mpm
 }
 
 export async function install(mpmPath: string, release: matlab.Release, products: string[], destination: string) {


### PR DESCRIPTION
The error is occurring when mpm was getting downloaded in second setup-matlab call as the file already exists.

Current fix is to check if mpm file exists before downloading it.