### PR TITLE
Add runtime directory to system PATH for windows

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -54,6 +54,10 @@ export async function install(platform: string, architecture: string, release: s
         core.setOutput('matlabroot', destination);
 
         await matlab.setupBatch(platform, matlabArch);
+        
+        if(platform === "win32") {
+            core.addPath(path.join(destination, "runtime", matlabArch));
+        }
     });
 
     return;

--- a/src/install.ts
+++ b/src/install.ts
@@ -55,8 +55,8 @@ export async function install(platform: string, architecture: string, release: s
 
         await matlab.setupBatch(platform, matlabArch);
         
-        if(platform === "win32") {
-            if(matlabArch === "x86") {
+        if (platform === "win32") {
+            if (matlabArch === "x86") {
                 core.addPath(path.join(destination, "runtime", "win32"));
             } else {
                 core.addPath(path.join(destination, "runtime", "win64"));

--- a/src/install.ts
+++ b/src/install.ts
@@ -56,7 +56,11 @@ export async function install(platform: string, architecture: string, release: s
         await matlab.setupBatch(platform, matlabArch);
         
         if(platform === "win32") {
-            core.addPath(path.join(destination, "runtime", matlabArch));
+            if(matlabArch === "x86") {
+                core.addPath(path.join(destination, "runtime", "win32"));
+            } else {
+                core.addPath(path.join(destination, "runtime", "win64"));
+            }
         }
     });
 

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -157,4 +157,12 @@ describe("install procedure", () => {
         expect(matlabSetupBatchMock).toHaveBeenCalledWith("darwin", "x64");
         expect(mpmSetupMock).toHaveBeenCalledWith("darwin", "x64");
     });
+
+    it("adds runtime path for Windows platform", async () => {
+        await expect(install.install("win32", arch, release, products, useCache)).resolves.toBeUndefined();
+        expect(addPathMock).toHaveBeenCalledTimes(2);
+        expect(addPathMock).toHaveBeenCalledWith(expect.stringContaining("bin"));
+        expect(addPathMock).toHaveBeenCalledWith(expect.stringContaining("runtime"));
+    });
+
 });


### PR DESCRIPTION
This PR adds the runtime directory to system path for windows OS, according to [mcr-path-settings-for-run-time-deployment](https://www.mathworks.com/help/compiler/mcr-path-settings-for-run-time-deployment.html), and resolves #129.