### PR TITLE
Cache when install successful

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 The MathWorks, Inc.
+# Copyright 2020-2025 The MathWorks, Inc.
 
 name: Setup MATLAB
 description: >-
@@ -27,4 +27,4 @@ runs:
   using: node20
   main: dist/setup/index.js
   post: dist/cache-save/index.js
-  post-if: success()
+  post-if: always()

--- a/src/install-state.ts
+++ b/src/install-state.ts
@@ -1,0 +1,5 @@
+// Copyright 2025 The MathWorks, Inc.
+
+export enum State {
+    InstallSuccessful = 'MATLAB_INSTALL_SUCCESSFUL',
+}

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,10 +1,11 @@
-// Copyright 2020-2024 The MathWorks, Inc.
+// Copyright 2020-2025 The MathWorks, Inc.
 
 import * as core from "@actions/core";
 import * as matlab from "./matlab";
 import * as mpm from "./mpm";
 import * as path from "path";
 import * as cache from "./cache-restore";
+import { State } from './install-state';
 
 /**
  * Set up an instance of MATLAB on the runner.
@@ -48,6 +49,7 @@ export async function install(platform: string, architecture: string, release: s
         if (!alreadyExists && !cacheHit) {
             const mpmPath: string = await mpm.setup(platform, matlabArch);
             await mpm.install(mpmPath, releaseInfo, products, destination);
+            core.saveState(State.InstallSuccessful, 'true');
         }
 
         core.addPath(path.join(destination, "bin"));

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -1,10 +1,11 @@
-// Copyright 2020-2024 The MathWorks, Inc.
+// Copyright 2020-2025 The MathWorks, Inc.
 
 import * as core from "@actions/core";
 import * as cache from "./cache-restore";
 import * as install from "./install";
 import * as matlab from "./matlab";
 import * as mpm from "./mpm";
+import { State } from './install-state';
 
 jest.mock("@actions/core");
 jest.mock("./matlab");
@@ -22,6 +23,7 @@ describe("install procedure", () => {
     let matlabSetupBatchMock: jest.Mock;
     let mpmSetupMock: jest.Mock;
     let mpmInstallMock: jest.Mock;
+    let saveStateMock: jest.Mock;
     let addPathMock: jest.Mock;
     let setOutputMock: jest.Mock;
     let restoreMATLABMock: jest.Mock;
@@ -49,6 +51,7 @@ describe("install procedure", () => {
         matlabSetupBatchMock = matlab.setupBatch as jest.Mock;
         mpmSetupMock = mpm.setup as jest.Mock;
         mpmInstallMock = mpm.install as jest.Mock;
+        saveStateMock = core.saveState as jest.Mock;
         addPathMock = core.addPath as jest.Mock;
         setOutputMock = core.setOutput as jest.Mock;
         restoreMATLABMock = cache.restoreMATLAB as jest.Mock;
@@ -71,6 +74,7 @@ describe("install procedure", () => {
         expect(matlabSetupBatchMock).toHaveBeenCalledTimes(1);
         expect(mpmSetupMock).toHaveBeenCalledTimes(1);
         expect(mpmInstallMock).toHaveBeenCalledTimes(1);
+        expect(saveStateMock).toHaveBeenCalledWith(State.InstallSuccessful, true);
         expect(addPathMock).toHaveBeenCalledTimes(1);
         expect(setOutputMock).toHaveBeenCalledTimes(1);
     });
@@ -79,6 +83,7 @@ describe("install procedure", () => {
         matlabGetToolcacheDirMock.mockResolvedValue(["/opt/hostedtoolcache/MATLAB/9.13.0/x64", true]);
         await expect(doInstall()).resolves.toBeUndefined();
         expect(mpmInstallMock).toHaveBeenCalledTimes(0);
+        expect(saveStateMock).toHaveBeenCalledTimes(0);
         expect(addPathMock).toHaveBeenCalledTimes(1);
         expect(setOutputMock).toHaveBeenCalledTimes(1);
     });
@@ -116,6 +121,7 @@ describe("install procedure", () => {
     it("rejects when the mpm install fails", async () => {
         mpmInstallMock.mockRejectedValue(Error("oof"));
         await expect(doInstall()).rejects.toBeDefined();
+        expect(saveStateMock).toHaveBeenCalledTimes(0);
     });
 
     it("rejects when the matlab-batch install fails", async () => {

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -74,7 +74,7 @@ describe("install procedure", () => {
         expect(matlabSetupBatchMock).toHaveBeenCalledTimes(1);
         expect(mpmSetupMock).toHaveBeenCalledTimes(1);
         expect(mpmInstallMock).toHaveBeenCalledTimes(1);
-        expect(saveStateMock).toHaveBeenCalledWith(State.InstallSuccessful, true);
+        expect(saveStateMock).toHaveBeenCalledWith(State.InstallSuccessful, 'true');
         expect(addPathMock).toHaveBeenCalledTimes(1);
         expect(setOutputMock).toHaveBeenCalledTimes(1);
     });

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,11 +1,13 @@
-// Copyright 2023 The MathWorks, Inc.
+// Copyright 2023-2025 The MathWorks, Inc.
 
 import * as core from "@actions/core";
 import { cacheMATLAB } from "./cache-save";
+import { State } from './install-state';
 
 export async function run() {
     const cache = core.getBooleanInput('cache');
-    if (cache) {
+    const installSuccessful = core.getState(State.InstallSuccessful);
+    if (cache && installSuccessful === 'true') {
         await cacheMATLAB();
     }
 }

--- a/src/post.unit.test.ts
+++ b/src/post.unit.test.ts
@@ -1,0 +1,44 @@
+// Copyright 2025 The MathWorks, Inc.
+
+import * as core from '@actions/core';
+import { cacheMATLAB } from "./cache-save";
+import { run } from "./post";
+
+jest.mock("@actions/core");
+jest.mock("./cache-save");
+
+afterEach(() => {
+    jest.resetAllMocks();
+});
+
+describe("post", () => {
+    let getBooleanInputMock: jest.Mock;
+    let getStateMock: jest.Mock;
+    let cacheMATLABMock: jest.Mock;
+
+    beforeEach(() => {
+        getBooleanInputMock = core.getBooleanInput as jest.Mock;
+        getStateMock = core.getState as jest.Mock;
+        cacheMATLABMock = cacheMATLAB as jest.Mock;
+    });
+
+    it("caches MATLAB when cache true and install successful", async () => {
+        getBooleanInputMock.mockReturnValueOnce(true);
+        getStateMock.mockReturnValueOnce('true');
+        await expect(run()).resolves.toBeUndefined();
+        expect(cacheMATLABMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not cache MATLAB when cache false", async () => {
+        getBooleanInputMock.mockReturnValueOnce(false);
+        getStateMock.mockReturnValueOnce('true');
+        await expect(run()).resolves.toBeUndefined();
+        expect(cacheMATLABMock).toHaveBeenCalledTimes(0);
+    });
+
+    it("does not cache MATLAB when install not successful", async () => {
+        getBooleanInputMock.mockReturnValueOnce(true);
+        await expect(run()).resolves.toBeUndefined();
+        expect(cacheMATLABMock).toHaveBeenCalledTimes(0);
+    });
+});


### PR DESCRIPTION
This change ensures that MATLAB is cached whenever MATLAB is installed successfully. Previously, MATLAB would only be cached if the job was successful.

See #145 