### PR TITLE
Add a `source` argument to setup-matlab

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,11 @@ inputs:
       MATLAB release to set up (R2021a or later)
     required: false
     default: latest
+  source:
+    description: >-
+      Path to mounted ISO image or directory set up with `mpm download`
+    required: false
+    default: ""
   products:
     description: >-
       Products to set up in addition to MATLAB, specified as a list of product names separated by spaces

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,13 @@ export async function run() {
     const platform = process.platform;
     const architecture = process.arch;
     const release = core.getInput("release");
+    const source = core.getInput("source");
     const products = core.getMultilineInput("products");
     const cache = core.getBooleanInput("cache");
+
+    if (source !== "") {
+        return install.installFromSource(platform, architecture, source, products);
+    }
     return install.install(platform, architecture, release, products, cache);
 }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -76,11 +76,10 @@ export async function install(platform: string, architecture: string, release: s
 // * Does not cache
 export async function installFromSource(platform: string, architecture: string, source: string, products: string[]) {
     // Create release key
-    const name = path.basename(source);
     const releaseKey = 'source-' + crypto.createHash('sha256').update(source).digest('hex');
     const releaseInfo = {
-        name: name,
-        version: releaseKey,
+        name: releaseKey,
+        version: "1.0.0",
         update: "",
         isPrerelease: false
     };

--- a/src/mpm.unit.test.ts
+++ b/src/mpm.unit.test.ts
@@ -180,4 +180,38 @@ describe("mpm install", () => {
         await expect(mpm.install(mpmPath, releaseInfo, products, destination)).rejects.toBeDefined();
         expect(rmRFMock).toHaveBeenCalledWith(destination);
     });
+
+    it("ideally works when installing from source", async () => {
+        const destination ="/opt/matlab";
+        const source = "/path/to/source";
+        const products = ["MATLAB", "Compiler"];
+        const expectedMpmArgs = [
+            "install",
+            `--source=${source}`,
+            `--destination=${destination}`,
+            "--products",
+            "MATLAB",
+            "Compiler",
+        ]
+        execMock.mockResolvedValue(0);
+
+        await expect(mpm.installFromSource(mpmPath, source, products, destination)).resolves.toBeUndefined();
+        expect(execMock.mock.calls[0][1]).toMatchObject(expectedMpmArgs);
+    });
+
+    it("rejects and cleans on mpm rejection when installing from source", async () => {
+        const destination = "/opt/matlab";
+        const products = ["MATLAB", "Compiler"];
+        execMock.mockRejectedValue(1);
+        await expect(mpm.installFromSource(mpmPath, "/path", products, destination)).rejects.toBeDefined();
+        expect(rmRFMock).toHaveBeenCalledWith(destination);
+    });
+
+    it("rejects and cleans on failed install when installing from source", async () => {
+        const destination = "/opt/matlab";
+        const products = ["MATLAB", "Compiler"];
+        execMock.mockResolvedValue(1);
+        await expect(mpm.installFromSource(mpmPath, "/path", products, destination)).rejects.toBeDefined();
+        expect(rmRFMock).toHaveBeenCalledWith(destination);
+    });
 });


### PR DESCRIPTION
This source argument acts as a pass through to `mpm`'s `--source` option. There are a couple of caveats for using it:
  1. If both `release` and `source` are specified, `source` is used for the installation and `release` is ignored.
  2. `source` is not supported with caching. If the `cache` argument is used with the `source` argument it will be ignored.
  3. Installations using the `source` argument will not install system dependencies, even on GitHub hosted runners.

Most of these caveats stem from the fact that we're unable to get the MATLAB version from the path provided by the `source` argument. This means we're unable to determine the correct dependencies to install. This is an area where there could be some discovery work in the future. 