### PR TITLE
Add GR fallback for prerelease

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -110,7 +110,7 @@ export async function install(
                 await mpm.install(mpmPath, releaseInfo, products, destination);
             } catch (e) {
                 if (releaseInfo.isPrerelease && e instanceof Error && e.message === "Specified release is unavailable") {
-                    core.info("Install failed, retrying...");
+                    core.info("Installation failed. Retrying...");
                     const grRelease: matlab.Release = {
                         ...releaseInfo,
                         isPrerelease: false,

--- a/src/install.ts
+++ b/src/install.ts
@@ -100,13 +100,12 @@ export async function install(
 
         if (!cacheHit) {
             const mpmPath: string = await mpm.setup(platform, matlabArch);
-
             // Workaround: When a new General Release ships, there is a lag
             // before latest-including-prerelease is updated. During this
-            // window the prerelease install fails because the release does
-            // not exist yet. Fall back to the General Release so the job
-            // can still succeed. Remove this once the release pipeline
-            // eliminates the lag.
+            // window the prerelease install fails because the prerelease is
+            // pulled. Fall back to the General Release so the job can still
+            // succeed. Remove this once the release procss eliminates the
+            // lag.
             try {
                 await mpm.install(mpmPath, releaseInfo, products, destination);
             } catch (e) {

--- a/src/install.ts
+++ b/src/install.ts
@@ -100,7 +100,30 @@ export async function install(
 
         if (!cacheHit) {
             const mpmPath: string = await mpm.setup(platform, matlabArch);
-            await mpm.install(mpmPath, releaseInfo, products, destination);
+
+            // Workaround: When a new General Release ships, there is a lag
+            // before latest-including-prerelease is updated. During this
+            // window the prerelease install fails because the release does
+            // not exist yet. Fall back to the General Release so the job
+            // can still succeed. Remove this once the release pipeline
+            // eliminates the lag.
+            try {
+                await mpm.install(mpmPath, releaseInfo, products, destination);
+            } catch (e) {
+                if (releaseInfo.isPrerelease) {
+                    core.info("Install failed, retrying...");
+                    const grRelease: matlab.Release = {
+                        ...releaseInfo,
+                        isPrerelease: false,
+                        version: releaseInfo.version.replace("-prerelease", ""),
+                    };
+                    destination = (await matlab.getToolcacheDir(platform, grRelease))[0];
+                    await mpm.install(mpmPath, grRelease, products, destination);
+                } else {
+                    throw e;
+                }
+            }
+
             core.saveState(State.InstallSuccessful, "true");
         }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -109,7 +109,11 @@ export async function install(
             try {
                 await mpm.install(mpmPath, releaseInfo, products, destination);
             } catch (e) {
-                if (releaseInfo.isPrerelease && e instanceof Error && e.message === "Specified release is unavailable") {
+                if (
+                    releaseInfo.isPrerelease &&
+                    e instanceof Error &&
+                    e.message === "Specified release is unavailable"
+                ) {
                     core.info("Installation failed. Retrying...");
                     const grRelease: matlab.Release = {
                         ...releaseInfo,

--- a/src/install.ts
+++ b/src/install.ts
@@ -109,7 +109,7 @@ export async function install(
             try {
                 await mpm.install(mpmPath, releaseInfo, products, destination);
             } catch (e) {
-                if (releaseInfo.isPrerelease) {
+                if (releaseInfo.isPrerelease && e instanceof Error && e.message === "Specified release is unavailable") {
                     core.info("Install failed, retrying...");
                     const grRelease: matlab.Release = {
                         ...releaseInfo,

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -336,9 +336,9 @@ describe("install procedure", () => {
             matlabGetReleaseInfoMock.mockResolvedValue(prereleaseInfo);
         });
 
-        it("retries with general release when prerelease install fails", async () => {
+        it("retries with general release when prerelease install fails with unavailable release", async () => {
             mpmInstallMock
-                .mockRejectedValueOnce(Error("Script exited with non-zero code 1"))
+                .mockRejectedValueOnce(Error("Specified release is unavailable"))
                 .mockResolvedValueOnce(undefined);
             matlabGetToolcacheDirMock
                 .mockResolvedValueOnce([
@@ -360,7 +360,7 @@ describe("install procedure", () => {
         });
 
         it("rejects when both prerelease and general release install fail", async () => {
-            mpmInstallMock.mockRejectedValue(Error("Script exited with non-zero code 1"));
+            mpmInstallMock.mockRejectedValue(Error("Specified release is unavailable"));
             matlabGetToolcacheDirMock
                 .mockResolvedValueOnce([
                     "/opt/hostedtoolcache/MATLAB/2026.1.999-prerelease/x64",
@@ -375,7 +375,18 @@ describe("install procedure", () => {
 
         it("does not retry for non-prerelease install failures", async () => {
             matlabGetReleaseInfoMock.mockResolvedValue(releaseInfo);
+            mpmInstallMock.mockRejectedValue(Error("Specified release is unavailable"));
+            await expect(doInstall()).rejects.toBeDefined();
+            expect(mpmInstallMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not retry prerelease install for other errors", async () => {
             mpmInstallMock.mockRejectedValue(Error("Script exited with non-zero code 1"));
+            matlabGetToolcacheDirMock.mockResolvedValueOnce([
+                "/opt/hostedtoolcache/MATLAB/2026.1.999-prerelease/x64",
+                false,
+            ]);
+
             await expect(doInstall()).rejects.toBeDefined();
             expect(mpmInstallMock).toHaveBeenCalledTimes(1);
         });

--- a/src/install.unit.test.ts
+++ b/src/install.unit.test.ts
@@ -322,4 +322,62 @@ describe("install procedure", () => {
         expect(addPathMock).toHaveBeenCalledWith(expect.stringContaining("bin"));
         expect(addPathMock).toHaveBeenCalledWith(expect.stringContaining("runtime"));
     });
+
+    describe("prerelease fallback to general release", () => {
+        const prereleaseInfo = {
+            name: "r2026a",
+            version: "2026.1.999-prerelease",
+            update: "",
+            isPrerelease: true,
+        };
+        const grDestination = "/opt/hostedtoolcache/MATLAB/2026.1.999/x64";
+
+        beforeEach(() => {
+            matlabGetReleaseInfoMock.mockResolvedValue(prereleaseInfo);
+        });
+
+        it("retries with general release when prerelease install fails", async () => {
+            mpmInstallMock
+                .mockRejectedValueOnce(Error("Script exited with non-zero code 1"))
+                .mockResolvedValueOnce(undefined);
+            matlabGetToolcacheDirMock
+                .mockResolvedValueOnce([
+                    "/opt/hostedtoolcache/MATLAB/2026.1.999-prerelease/x64",
+                    false,
+                ])
+                .mockResolvedValueOnce([grDestination, false]);
+
+            await expect(doInstall()).resolves.toBeUndefined();
+            expect(mpmInstallMock).toHaveBeenCalledTimes(2);
+            // Second call should be without prerelease
+            const secondCall = mpmInstallMock.mock.calls[1];
+            expect(secondCall[1]).toMatchObject({
+                isPrerelease: false,
+                version: "2026.1.999",
+            });
+            expect(saveStateMock).toHaveBeenCalledWith(State.InstallSuccessful, "true");
+            expect(addPathMock).toHaveBeenCalledWith(expect.stringContaining(grDestination));
+        });
+
+        it("rejects when both prerelease and general release install fail", async () => {
+            mpmInstallMock.mockRejectedValue(Error("Script exited with non-zero code 1"));
+            matlabGetToolcacheDirMock
+                .mockResolvedValueOnce([
+                    "/opt/hostedtoolcache/MATLAB/2026.1.999-prerelease/x64",
+                    false,
+                ])
+                .mockResolvedValueOnce([grDestination, false]);
+
+            await expect(doInstall()).rejects.toBeDefined();
+            expect(mpmInstallMock).toHaveBeenCalledTimes(2);
+            expect(saveStateMock).toHaveBeenCalledTimes(0);
+        });
+
+        it("does not retry for non-prerelease install failures", async () => {
+            matlabGetReleaseInfoMock.mockResolvedValue(releaseInfo);
+            mpmInstallMock.mockRejectedValue(Error("Script exited with non-zero code 1"));
+            await expect(doInstall()).rejects.toBeDefined();
+            expect(mpmInstallMock).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/src/mpm.ts
+++ b/src/mpm.ts
@@ -114,6 +114,10 @@ export async function install(
         throw e;
     });
 
+    if (exitCode !== 0 && output.toLowerCase().includes("specified release is unavailable")) {
+        await rmRF(destination);
+        return Promise.reject(Error("Specified release is unavailable"));
+    }
     if (exitCode !== 0 && !output.toLowerCase().includes("already installed")) {
         await rmRF(destination);
         return Promise.reject(Error(`Script exited with non-zero code ${exitCode}`));

--- a/src/mpm.unit.test.ts
+++ b/src/mpm.unit.test.ts
@@ -213,6 +213,23 @@ describe("mpm install", () => {
         expect(rmRFMock).toHaveBeenCalledWith(destination);
     });
 
+    it("rejects with specific message when output includes specified release is unavailable", async () => {
+        const destination = "/opt/matlab";
+        const products = ["MATLAB", "Compiler"];
+
+        execMock.mockImplementation((cmd: string, args?: string[], options?: ExecOptions) => {
+            if (options && options.listeners && typeof options.listeners.stderr === "function") {
+                options.listeners.stderr(Buffer.from("Error: Specified release is unavailable."));
+            }
+            return Promise.resolve(1);
+        });
+
+        await expect(mpm.install(mpmPath, releaseInfo, products, destination)).rejects.toThrow(
+            "Specified release is unavailable",
+        );
+        expect(rmRFMock).toHaveBeenCalledWith(destination);
+    });
+
     it("does not reject when mpm exits non-zero but reports already installed", async () => {
         const destination = "/opt/matlab";
         const products = ["MATLAB", "Compiler"];


### PR DESCRIPTION
Currently there is lag in the process of updating the supported GR and prereleases in CI. In that window `latest-including-prerelease` fails. This change retries the install with the GR if the prerelease fails (Ex: R2026a-prerelease fails -> try to install R2026a).  You can see what this looks like in the logs for this workflow https://github.com/matlab-actions/setup-matlab/actions/runs/24838466441/job/72705433899